### PR TITLE
Add drag handlers

### DIFF
--- a/src/tree-item.vue
+++ b/src/tree-item.vue
@@ -4,9 +4,9 @@
         :draggable="draggable"
         @dragstart.stop="onItemDragStart($event, _self, _self.model)"
         @dragend.stop.prevent="onItemDragEnd($event, _self, _self.model)"
-        @dragover.stop.prevent="isDragEnter = true"
-        @dragenter.stop.prevent="isDragEnter = true"
-        @dragleave.stop.prevent="isDragEnter = false"
+        @dragover.stop.prevent="handleDragOver($event, _self, _self.model)"
+        @dragenter.stop.prevent="handleDragEnter($event, _self, _self.model)"
+        @dragleave.stop.prevent="handleDragLeave($event, _self, _self.model)"
         @drop.stop.prevent="handleItemDrop($event, _self, _self.model)">
         <div role="presentation" :class="wholeRowClasses" v-if="isWholeRow">&nbsp;</div>
         <i class="tree-icon tree-ocl" role="presentation" @click="handleItemToggle"></i>
@@ -36,6 +36,9 @@
                        :on-item-toggle="onItemToggle"
                        :on-item-drag-start="onItemDragStart"
                        :on-item-drag-end="onItemDragEnd"
+                       :on-item-drag-over="onItemDragOver"
+                       :on-item-drag-enter="onItemDragEnter"
+                       :on-item-drag-leave="onItemDragLeave"
                        :on-item-drop="onItemDrop"
                        :klass="index === model[childrenFieldName].length-1?'tree-last':''">
                 <template slot-scope="_">
@@ -74,6 +77,15 @@
               type: Function, default: () => false
           },
           onItemDragEnd: {
+              type: Function, default: () => false
+          },
+          onItemDragOver: {
+              type: Function, default: () => false
+          },
+          onItemDragEnter: {
+              type: Function, default: () => false
+          },
+          onItemDragLeave: {
               type: Function, default: () => false
           },
           onItemDrop: {
@@ -195,6 +207,18 @@
               if (this.model.disabled) return
               this.model.selected = !this.model.selected
               this.onItemClick(this, this.model, e)
+          },
+          handleDragOver (e, oriNode, oriItem) {
+              this.isDragEnter = true
+              this.onItemDragOver(e, oriNode, oriItem)
+          },
+          handleDragEnter (e, oriNode, oriItem) {
+              this.isDragEnter = true
+              this.onItemDragEnter(e, oriNode, oriItem)
+          },
+          handleDragLeave (e, oriNode, oriItem) {
+              this.isDragEnter = false
+              this.onItemDragLeave(e, oriNode, oriItem)
           },
           handleItemMouseOver () {
               this.isHover = true

--- a/src/tree.vue
+++ b/src/tree.vue
@@ -19,6 +19,9 @@
                        :on-item-toggle="onItemToggle"
                        :on-item-drag-start="onItemDragStart"
                        :on-item-drag-end="onItemDragEnd"
+                       :on-item-drag-over="onItemDragOver"
+                       :on-item-drag-enter="onItemDragEnter"
+                       :on-item-drag-leave="onItemDragLeave"
                        :on-item-drop="onItemDrop"
                        :klass="index === data.length-1?'tree-last':''">
                 <template slot-scope="_">
@@ -249,6 +252,15 @@
                 this.draggedItem = undefined
                 this.draggedElm = undefined
                 this.$emit("item-drag-end", oriNode, oriItem, e)
+            },
+            onItemDragOver(e, oriNode, oriItem) {
+                this.$emit("item-drag-over", oriNode, oriItem, e)
+            },
+            onItemDragEnter(e, oriNode, oriItem) {
+                this.$emit("item-drag-enter", oriNode, oriItem, e)
+            },
+            onItemDragLeave(e, oriNode, oriItem) {
+                this.$emit("item-drag-leave", oriNode, oriItem, e)
             },
             onItemDrop(e, oriNode, oriItem) {
                 if (!this.draggable || !!oriItem.dropDisabled)

--- a/src/tree.vue
+++ b/src/tree.vue
@@ -254,13 +254,13 @@
                 this.$emit("item-drag-end", oriNode, oriItem, e)
             },
             onItemDragOver(e, oriNode, oriItem) {
-                this.$emit("item-drag-over", oriNode, oriItem, e)
+                this.$emit("item-drag-over", oriNode, oriItem, !this.draggedItem ? undefined : this.draggedItem.item, e)
             },
             onItemDragEnter(e, oriNode, oriItem) {
-                this.$emit("item-drag-enter", oriNode, oriItem, e)
+                this.$emit("item-drag-enter", oriNode, oriItem, !this.draggedItem ? undefined : this.draggedItem.item, e)
             },
             onItemDragLeave(e, oriNode, oriItem) {
-                this.$emit("item-drag-leave", oriNode, oriItem, e)
+                this.$emit("item-drag-leave", oriNode, oriItem, !this.draggedItem ? undefined : this.draggedItem.item, e)
             },
             onItemDrop(e, oriNode, oriItem) {
                 if (!this.draggable || !!oriItem.dropDisabled)


### PR DESCRIPTION
Fix #53 

As described in the issue, there is currently no way to trigger a function on hover. I added callbacks/handlers to the existing `@drag*` events in `tree-item.vue`.

In my code I can now use something like this:
```vue
<template>
    <v-jstree
        :async="loadAsync"
        :data="tree"
        :draggable="true"
        @item-drag-enter="itemDragEnter"
        @item-drag-leave="itemDragLeave">
        <div slot-scope="_">
            {{_.model.name}}
        </div>
    </v-jstree>
</template>

<script>
    ...
    itemDragEnter(node, item, e) {
        const vm = this;
        if(vm.timeoutId) {
            clearTimeout(vm.timeoutId);
        }
        vm.timeoutId = setTimeout(function() {
            // I use children_count to check if there are any children to load async
            if(!item.opened && item.children_count) {
                item.opened = true;
            }
            vm.timeoutId = 0;
        }, vm.delay);
    },
    itemDragLeave(node, item, e) {
    },
    ...
</script>
```

Using this PR and snippet, I am able to open an item after a desired timeout, so it does not expand all items on drag over.

@zdy1988 Is this ok? Please review and comment. If there is anything missing, please let me know and I'll fix it :)