### PR TITLE
Fixed drag & drop bug in IE 11

### DIFF
--- a/src/tree.vue
+++ b/src/tree.vue
@@ -235,7 +235,7 @@
                 if (!this.draggable || oriItem.dragDisabled)
                     return false
                 e.dataTransfer.effectAllowed = "move"
-                e.dataTransfer.setData('text', null)
+                e.dataTransfer.setData('text', '')
                 this.draggedElm = e.target
                 this.draggedItem = {
                     item: oriItem,


### PR DESCRIPTION
On drag start's dataTransfer store, the setData() function only accepts a DOMString as second arguments, according to https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/setData

While modern browsers stringify the null data type to "null" string value, drag & drop functionality breaks in IE 11 when passing null to e.dataTranser.setData('text', null)

I simply fixed this by passing an empty string to the setData() function.