### PR TITLE
Add semi check for tree items

### DIFF
--- a/src/less/mixins.less
+++ b/src/less/mixins.less
@@ -34,6 +34,9 @@
 		&.tree-selected {
 			background:#efefef;
 		}
+		&.tree-determined {
+			background:#efefef;
+		}
 	}
 
 	.tree-checkbox {
@@ -45,6 +48,12 @@
 		> .tree-checkbox {
 			background-position:-(@image-height * 7 + @correction) -@correction;
 			&:hover { background-position:-(@image-height * 7 + @correction) -(@image-height * 1 + @correction); }
+		}
+	}
+	&.tree-checkbox-selection .tree-determined, .tree-checked {
+		> .tree-checkbox {
+			background-position:-(@image-height * 6 + @correction) -@correction;
+			&:hover { background-position:-(@image-height * 6 + @correction) -(@image-height * 1 + @correction); }
 		}
 	}
 	.tree-anchor {

--- a/src/tree.vue
+++ b/src/tree.vue
@@ -11,6 +11,8 @@
                        :whole-row="wholeRow"
                        :show-checkbox="showCheckbox"
                        :allow-transition="allowTransition"
+                       :allow-batch="allowBatch"
+                       :semiCheck="semiCheck"
                        :height="sizeHeight"
                        :parent-item="data"
                        :draggable="draggable"
@@ -54,6 +56,7 @@
             textFieldName: {type: String, default: 'text'},
             valueFieldName: {type: String, default: 'value'},
             childrenFieldName: {type: String, default: 'children'},
+            semiCheck: {type: Boolean, default: true},
             itemEvents: {
                 type: Object, default: function () {
                     return {}


### PR DESCRIPTION
Added prop 'semiCheck'. If it's true and tree-item isn't selected but has selected children, then in parent's checkbox you will see a special square. So you can easily understand whether an item has selected children or not.